### PR TITLE
Prevent actor cells creation under same ID

### DIFF
--- a/actor/futures.go
+++ b/actor/futures.go
@@ -10,7 +10,7 @@ func RequestResponsePID() (*PID, *Response) {
 		channel: make(chan interface{}, 1),
 	}
 	id := ProcessRegistry.getAutoId()
-	pid := ProcessRegistry.registerPID(ref, id)
+	pid, _ := ProcessRegistry.registerPID(ref, id)
 	return pid, ref
 }
 

--- a/actor/process_registry.go
+++ b/actor/process_registry.go
@@ -30,7 +30,7 @@ func (pr *ProcessRegistryValue) getAutoId() string {
 	return id
 }
 
-func (pr *ProcessRegistryValue) registerPID(actorRef ActorRef, id string) *PID {
+func (pr *ProcessRegistryValue) registerPID(actorRef ActorRef, id string) (*PID, bool) {
 
 	pid := PID{
 		Host: pr.Host,
@@ -39,8 +39,12 @@ func (pr *ProcessRegistryValue) registerPID(actorRef ActorRef, id string) *PID {
 
 	pr.rw.Lock()
 	defer pr.rw.Unlock()
+	_, found := pr.LocalPids[pid.Id]
+	if found {
+		return &pid, false
+	}
 	pr.LocalPids[pid.Id] = actorRef
-	return &pid
+	return &pid, true
 }
 
 func (pr *ProcessRegistryValue) unregisterPID(pid *PID) {

--- a/actor/router.go
+++ b/actor/router.go
@@ -37,7 +37,7 @@ func spawnRouter(config RouterConfig, props Props, parent *PID) *PID {
 		state:  routerState,
 	}
 	proxyID := ProcessRegistry.getAutoId()
-	proxy := ProcessRegistry.registerPID(ref, proxyID)
+	proxy, _ := ProcessRegistry.registerPID(ref, proxyID)
 	return proxy
 }
 

--- a/actor/spawn.go
+++ b/actor/spawn.go
@@ -18,11 +18,14 @@ func spawn(id string, props Props, parent *PID) *PID {
 
 	cell := NewActorCell(props, parent)
 	mailbox := props.ProduceMailbox()
-	mailbox.RegisterHandlers(cell.invokeUserMessage, cell.invokeSystemMessage)
 	ref := NewLocalActorRef(mailbox)
-	pid := ProcessRegistry.registerPID(ref, id)
-	cell.self = pid
+	pid, new := ProcessRegistry.registerPID(ref, id)
 
-	cell.invokeUserMessage(&Started{})
+	if new {
+		mailbox.RegisterHandlers(cell.invokeUserMessage, cell.invokeSystemMessage)
+		cell.self = pid
+		cell.invokeUserMessage(&Started{})
+	}
+
 	return pid
 }

--- a/actor/spawn_test.go
+++ b/actor/spawn_test.go
@@ -1,0 +1,69 @@
+package actor
+
+import (
+	"log"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type Increment struct {
+	Sender *PID
+}
+
+type Incrementable interface {
+	Increment()
+}
+
+type GorgeousActor struct {
+	Counter
+}
+
+type Counter struct {
+	value int
+}
+
+func (counter *Counter) Increment() {
+	counter.value = counter.value + 1
+}
+
+func (a *GorgeousActor) Receive(context Context) {
+	switch msg := context.Message().(type) {
+	case *Started:
+		log.Printf("Started %s", a)
+	case Increment:
+		log.Printf("Incrementing %v", a)
+		a.Increment()
+		msg.Sender.Tell(a.value)
+	}
+}
+
+func TestLookupById(t *testing.T) {
+	ID := "UniqueID"
+	responsePID, result := RequestResponsePID()
+	{
+		props := FromInstance(&GorgeousActor{Counter: Counter{value: 0}})
+		actor := SpawnNamed(props, ID)
+		defer actor.Stop()
+		actor.Tell(Increment{Sender: responsePID})
+		value, err := result.ResultOrTimeout(testTimeout)
+		if err != nil {
+			assert.Fail(t, "timed out")
+			return
+		}
+		assert.IsType(t, int(0), value)
+		assert.Equal(t, 1, value.(int))
+	}
+	{
+		props := FromInstance(&GorgeousActor{Counter: Counter{value: 0}})
+		actor := SpawnNamed(props, ID)
+		actor.Tell(Increment{Sender: responsePID})
+		value, err := result.ResultOrTimeout(10 * time.Second)
+		if err != nil {
+			assert.Fail(t, "timed out")
+			return
+		}
+		assert.Equal(t, 2, value.(int))
+	}
+}


### PR DESCRIPTION
Hi, @rogeralsing!

The project lacks the API to 'lookup or create" actor and spawning actors under same ID does not give any error.
Have a look at the test and fix