### PR TITLE
Replaced hashmap + rwlock with ctrie in ProcessRegistry

### DIFF
--- a/actor/process_registry.go
+++ b/actor/process_registry.go
@@ -1,12 +1,10 @@
 package actor
 
 import (
-	"log"
 	"strconv"
-	"sync"
 	"sync/atomic"
 
-    "github.com/Workiva/go-datastructures/trie/ctrie"
+	"github.com/Workiva/go-datastructures/trie/ctrie"
 )
 
 type HostResolver func(*PID) (ActorRef, bool)
@@ -49,7 +47,7 @@ func (pr *ProcessRegistryValue) registerPID(actorRef ActorRef, id string) (*PID,
 }
 
 func (pr *ProcessRegistryValue) unregisterPID(pid *PID) {
-    pr.LocalPids.Remove([]byte(pid.Id))
+	pr.LocalPids.Remove([]byte(pid.Id))
 }
 
 func (pr *ProcessRegistryValue) fromPID(pid *PID) (ActorRef, bool) {
@@ -69,10 +67,10 @@ func (pr *ProcessRegistryValue) fromPID(pid *PID) (ActorRef, bool) {
 		return deadLetter, false
 	}
 
-	if original, ok := ref.(ActorRef), ok{
+	if original, ok := ref.(ActorRef); ok {
 		return original, true
-    } else {
+	} else {
 		return deadLetter, false
-    }
+	}
 
 }

--- a/actor/process_registry.go
+++ b/actor/process_registry.go
@@ -1,24 +1,26 @@
 package actor
 
 import (
+	"log"
 	"strconv"
 	"sync"
 	"sync/atomic"
+
+    "github.com/Workiva/go-datastructures/trie/ctrie"
 )
 
 type HostResolver func(*PID) (ActorRef, bool)
 
 type ProcessRegistryValue struct {
 	Host           string
-	LocalPids      map[string]ActorRef //maybe this should be replaced with something lockfree like ctrie instead
+	LocalPids      *ctrie.Ctrie
 	RemoteHandlers []HostResolver
 	SequenceID     uint64
-	rw             sync.RWMutex
 }
 
 var ProcessRegistry = &ProcessRegistryValue{
 	Host:           "nonhost",
-	LocalPids:      make(map[string]ActorRef),
+	LocalPids:      ctrie.New(nil),
 	RemoteHandlers: make([]HostResolver, 0),
 }
 
@@ -38,21 +40,16 @@ func (pr *ProcessRegistryValue) registerPID(actorRef ActorRef, id string) (*PID,
 		Id:   id,
 	}
 
-	pr.rw.Lock()
-	_, found := pr.LocalPids[pid.Id]
+	_, found := pr.LocalPids.Lookup([]byte(pid.Id))
 	if found {
-	    pr.rw.Unlock()
 		return &pid, false
 	}
-	pr.LocalPids[pid.Id] = actorRef
-	pr.rw.Unlock()
+	pr.LocalPids.Insert([]byte(pid.Id), actorRef)
 	return &pid, true
 }
 
 func (pr *ProcessRegistryValue) unregisterPID(pid *PID) {
-	pr.rw.Lock()
-	delete(pr.LocalPids, pid.Id)
-	pr.rw.Unlock()
+    pr.LocalPids.Remove([]byte(pid.Id))
 }
 
 func (pr *ProcessRegistryValue) fromPID(pid *PID) (ActorRef, bool) {
@@ -66,13 +63,16 @@ func (pr *ProcessRegistryValue) fromPID(pid *PID) (ActorRef, bool) {
 		//panic("Unknown host or node")
 		return deadLetter, false
 	}
-	pr.rw.RLock()
-	ref, ok := pr.LocalPids[pid.Id]
+	ref, ok := pr.LocalPids.Lookup([]byte(pid.Id))
 	if !ok {
 		//panic("Unknown PID")
-	    pr.rw.RUnlock()
 		return deadLetter, false
 	}
-	pr.rw.RUnlock()
-	return ref, true
+
+	if original, ok := ref.(ActorRef), ok{
+		return original, true
+    } else {
+		return deadLetter, false
+    }
+
 }


### PR DESCRIPTION
With ctrie the performance is 2x better in comparison with map+lock; for scenarios where the contention is high. 