### PR TITLE
UnboundedMailbox: simple fix to avoid goroutine overhead

### DIFF
--- a/actor/unbounded_mailbox.go
+++ b/actor/unbounded_mailbox.go
@@ -46,18 +46,19 @@ func (mailbox *unboundedMailbox) processMessages() {
 	//we are about to start processing messages, we can safely reset the message flag of the mailbox
 	atomic.StoreInt32(&mailbox.hasMoreMessages, mailboxHasNoMessages)
 
-	done := false
-	for !done {
+	done := 0
+	for done != 5 {
 		//process x messages in sequence, then exit
 		for i := 0; i < mailbox.throughput; i++ {
 			if sysMsg, ok := mailbox.systemMailbox.Pop(); ok {
+				done = 0
 				sys, _ := sysMsg.(SystemMessage)
 				mailbox.systemInvoke(sys)
 			} else if userMsg, ok := mailbox.userMailbox.Pop(); ok {
-
+				done = 0
 				mailbox.userInvoke(userMsg.(UserMessage))
 			} else {
-				done = true
+				done++
 				break
 			}
 		}


### PR DESCRIPTION
To avoid destroying and recreating goroutines for handling messages,
in cases where the inter-arrival time of messages is not short
enough or long enough to prevent the goroutine from exiting, it is
better to simply wait and check the queues a few time before letting
go of the goroutine. This adds a bit of CPU utilization and possibly
small memory overhead, but boost the performance for those corner
cases almost 3 times.

It can be changed to a configurable variable later to be tuned depending 
on the workload. 