### PR TITLE
Revert "Replaced hashmap + rwlock with ctrie in ProcessRegistry"

### DIFF
--- a/actor/process_registry.go
+++ b/actor/process_registry.go
@@ -2,23 +2,23 @@ package actor
 
 import (
 	"strconv"
+	"sync"
 	"sync/atomic"
-
-	"github.com/Workiva/go-datastructures/trie/ctrie"
 )
 
 type HostResolver func(*PID) (ActorRef, bool)
 
 type ProcessRegistryValue struct {
 	Host           string
-	LocalPids      *ctrie.Ctrie
+	LocalPids      map[string]ActorRef //maybe this should be replaced with something lockfree like ctrie instead
 	RemoteHandlers []HostResolver
 	SequenceID     uint64
+	rw             sync.RWMutex
 }
 
 var ProcessRegistry = &ProcessRegistryValue{
 	Host:           "nonhost",
-	LocalPids:      ctrie.New(nil),
+	LocalPids:      make(map[string]ActorRef),
 	RemoteHandlers: make([]HostResolver, 0),
 }
 
@@ -38,16 +38,21 @@ func (pr *ProcessRegistryValue) registerPID(actorRef ActorRef, id string) (*PID,
 		Id:   id,
 	}
 
-	_, found := pr.LocalPids.Lookup([]byte(pid.Id))
+	pr.rw.Lock()
+	_, found := pr.LocalPids[pid.Id]
 	if found {
+	    pr.rw.Unlock()
 		return &pid, false
 	}
-	pr.LocalPids.Insert([]byte(pid.Id), actorRef)
+	pr.LocalPids[pid.Id] = actorRef
+	pr.rw.Unlock()
 	return &pid, true
 }
 
 func (pr *ProcessRegistryValue) unregisterPID(pid *PID) {
-	pr.LocalPids.Remove([]byte(pid.Id))
+	pr.rw.Lock()
+	delete(pr.LocalPids, pid.Id)
+	pr.rw.Unlock()
 }
 
 func (pr *ProcessRegistryValue) fromPID(pid *PID) (ActorRef, bool) {
@@ -61,16 +66,13 @@ func (pr *ProcessRegistryValue) fromPID(pid *PID) (ActorRef, bool) {
 		//panic("Unknown host or node")
 		return deadLetter, false
 	}
-	ref, ok := pr.LocalPids.Lookup([]byte(pid.Id))
+	pr.rw.RLock()
+	ref, ok := pr.LocalPids[pid.Id]
 	if !ok {
 		//panic("Unknown PID")
+	    pr.rw.RUnlock()
 		return deadLetter, false
 	}
-
-	if original, ok := ref.(ActorRef); ok {
-		return original, true
-	} else {
-		return deadLetter, false
-	}
-
+	pr.rw.RUnlock()
+	return ref, true
 }


### PR DESCRIPTION
Reverts AsynkronIT/gam#29

Temp Revert of ctrie PID lookup due to lookup performance regression.
Will re introduce once overall performance improvement is verified.