### PR TITLE
delay spawn until services are started

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -24,6 +24,7 @@ func Start(ip string, join ...string) {
 	if err != nil {
 		panic("[CLUSTER] Failed to create memberlist: " + err.Error())
 	}
+	spawnPartitionActor()
 	list = l
 	remoting.Start(name)
 

--- a/cluster/partition_actor.go
+++ b/cluster/partition_actor.go
@@ -9,8 +9,12 @@ import (
 )
 
 var (
-	partitionPid = actor.SpawnNamed(actor.FromProducer(newClusterActor()), "partition")
+	partitionPid *actor.PID
 )
+
+func spawnPartitionActor() {
+	partitionPid = actor.SpawnNamed(actor.FromProducer(newClusterActor()), "partition")
+}
 
 func partitionForHost(host string) *actor.PID {
 	pid := actor.NewPID(host, "partition")

--- a/remoting/activator_actor.go
+++ b/remoting/activator_actor.go
@@ -10,8 +10,12 @@ import (
 
 var (
 	nameLookup   = make(map[string]actor.Props)
-	activatorPid = actor.SpawnNamed(actor.FromProducer(newActivatorActor()), "activator")
+	activatorPid *actor.PID
 )
+
+func spawnActivatorActor() {
+	activatorPid = actor.SpawnNamed(actor.FromProducer(newActivatorActor()), "activator")
+}
 
 //Register a known actor props by name
 func Register(kind string, props actor.Props) {

--- a/remoting/server.go
+++ b/remoting/server.go
@@ -20,6 +20,8 @@ func Start(host string, options ...RemotingOption) {
 		option(config)
 	}
 
+	spawnActivatorActor()
+
 	host = lis.Addr().String()
 	actor.ProcessRegistry.RegisterHostResolver(remoteHandler)
 	actor.ProcessRegistry.Host = host


### PR DESCRIPTION
ensures these aren't spawned in unit tests or create other unintended side effects when importing these packages