### PR TITLE
use id for router PID

### DIFF
--- a/actor/router.go
+++ b/actor/router.go
@@ -39,8 +39,7 @@ func (config *PoolRouter) OnStarted(context Context, props Props, router RouterS
 	router.SetRoutees(routees)
 }
 
-func spawnRouter(config RouterConfig, props Props, parent *PID) *PID {
-	id := ProcessRegistry.getAutoId()
+func spawnRouter(id string, config RouterConfig, props Props, parent *PID) *PID {
 	routeeProps := props
 	routeeProps.routerConfig = nil
 	routerState := config.CreateRouterState()

--- a/actor/spawn.go
+++ b/actor/spawn.go
@@ -15,7 +15,7 @@ func SpawnNamed(props Props, name string) *PID {
 
 func spawn(id string, props Props, parent *PID) *PID {
 	if props.RouterConfig() != nil {
-		return spawnRouter(props.RouterConfig(), props, parent)
+		return spawnRouter(id, props.RouterConfig(), props, parent)
 	}
 
 	cell := NewActorCell(props, parent)


### PR DESCRIPTION
Allows router actors to be located by name